### PR TITLE
fasttext 0.9.3 (fix) :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - pip ==25.0
+    - pip !=25.1
     - pybind11 >=2.2
     - python
     - setuptools >=0.7.0
@@ -33,7 +33,7 @@ requirements:
 
 test:
   requires:
-    - pip ==25.0
+    - pip
   imports:
     - fasttext
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,10 @@ source:
   sha256: eb03f2ef6340c6ac9e4398a30026f05471da99381b307aafe2f56e4cd26baaef
 
 build:
-  number: 0
+  number: 1
   # pybind11 seems incompatible on win
   skip: True  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  missing_dso_whitelist:
-    - $RPATH/ld64.so.1  # [s390x]
 
 requirements:
   build:
@@ -27,7 +25,7 @@ requirements:
     - setuptools >=0.7.0
     - wheel
   run:
-    - numpy >=1.17
+    - numpy >=1.17, <2
     - pybind11 >=2.2
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 1
   # pybind11 seems incompatible on win
   skip: True  # [win]
+  # numpy<2 not available for py313
+  skip: True  # [py>=313]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools >=0.7.0
     - wheel
   run:
-    - numpy >=1.17, <2
+    - numpy >=1.17,<2
     - pybind11 >=2.2
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - pip
+    - pip ==25.0
     - pybind11 >=2.2
     - python
     - setuptools >=0.7.0
@@ -33,7 +33,7 @@ requirements:
 
 test:
   requires:
-    - pip
+    - pip ==25.0
   imports:
     - fasttext
   commands:


### PR DESCRIPTION
fasttext 0.9.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-7866]
- dev_url:        https://github.com/facebookresearch/fastText/tree/main
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- introducing and upper bound on `numpy`


[PKG-7866]: https://anaconda.atlassian.net/browse/PKG-7866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ